### PR TITLE
use time 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "basic-human-duration"
 description = "Simple human formatting of chrono::Duration"
-version = "0.1.2"
+version = "0.2.0"
 license = "Apache-2.0/MIT"
 authors = ["Richard Dodd <richard.o.dodd@gmail.com>", "Smail Barkouch <smailbarkouch1@gmail.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 repository = "https://github.com/SmailBarkouch/chrono-human-duration"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-chrono = "0.4.10"
+time = "0.3.20"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-use chrono::Duration;
 use std::fmt;
+use time::Duration;
 
 pub trait ChronoHumanDuration {
     type Displayer: fmt::Display;
@@ -22,12 +22,12 @@ impl fmt::Display for Displayer {
         let mut wrote = false;
         let d = self.d;
 
-        let months = d.num_weeks() / 4;
+        let months = d.whole_weeks() / 4;
         if months > 0 {
             write!(f, "{} month{}", months, if months > 1 { "s" } else { "" })?;
             wrote = true;
         } else {
-            let weeks = d.num_weeks();
+            let weeks = d.whole_weeks();
             if weeks > 0 {
                 write!(
                     f,
@@ -38,7 +38,7 @@ impl fmt::Display for Displayer {
                 )?;
                 wrote = true;
             } else {
-                let days = d.num_days();
+                let days = d.whole_days();
                 if days > 0 {
                     write!(
                         f,
@@ -49,7 +49,7 @@ impl fmt::Display for Displayer {
                     )?;
                     wrote = true;
                 } else {
-                    let hours = d.num_hours();
+                    let hours = d.whole_hours();
                     if hours > 0 {
                         write!(
                             f,
@@ -60,7 +60,7 @@ impl fmt::Display for Displayer {
                         )?;
                         wrote = true;
                     } else {
-                        let minutes = d.num_minutes();
+                        let minutes = d.whole_minutes();
                         if minutes > 0 {
                             write!(
                                 f,
@@ -86,8 +86,8 @@ impl fmt::Display for Displayer {
 
 #[cfg(test)]
 mod tests {
-    use super::ChronoHumanDuration;
-    use chrono::Duration;
+    use time::Duration;
+    use crate::ChronoHumanDuration;
 
     #[test]
     fn it_works() {


### PR DESCRIPTION
[chrono has a vuln](https://github.com/chronotope/chrono/issues/602), it seems the resolution is to use `time 0.3`.

cargo audit before:
```
parth@archlinux ~/D/l/basic-human-duration (master)> cargo audit 
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 539 security advisories (from /home/parth/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (50 crate dependencies)
Crate:     time
Version:   0.1.45
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Severity:  6.2 (medium)
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.45
└── chrono 0.4.24
    └── basic-human-duration 0.1.2

error: 1 vulnerability found!
```

after:

```
parth@archlinux ~/D/l/basic-human-duration (move-to-time-0-3)> cargo audit 
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 539 security advisories (from /home/parth/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (4 crate dependencies)
```